### PR TITLE
Read SWC file from buffer

### DIFF
--- a/navis/io/swc_io.py
+++ b/navis/io/swc_io.py
@@ -20,12 +20,14 @@ import requests
 from pathlib import Path
 from textwrap import dedent
 import multiprocessing as mp
-from typing import List, Union, Iterable, Dict, Optional, Any, TextIO, IO, Tuple
+from typing import List, Union, Iterable, Dict, Optional, Any, TextIO, IO
 
 import pandas as pd
 import numpy as np
 
 from .. import config, utils, core
+
+__all__ = ["SwcReader", "read_swc", "write_swc"]
 
 # Set up logging
 logger = config.logger
@@ -812,23 +814,3 @@ def make_swc_table(x: 'core.TreeNeuron',
         return swc, node_map
 
     return swc
-
-
-def to_float(x: Any) -> Optional[float]:
-    """Try to convert to float."""
-    try:
-        return float(x)
-    except BaseException:
-        return None
-
-
-def to_int(x: Any) -> Optional[int]:
-    """Try to convert to int."""
-    try:
-        return int(x)
-    except BaseException:
-        return None
-
-def _worker_wrapper(kwargs):
-    """Helper for importing SWCs using multiple processes."""
-    return read_swc(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ Check out the `Documentation <http://navis.readthedocs.io/>`_.
 setup(
     name='navis',
     version=verstr,
-    packages=find_packages(),
+    packages=find_packages(include=["navis"]),
     license='GNU GPL V3',
     description='Neuron Analysis and Visualization library',
     long_description=LONG_DESCRIPTION,

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,21 @@
+import warnings
+
+try:
+    import igraph
+except ImportError:
+    igraph = None
+    warnings.warn('iGraph library not found. Will test only with NetworkX.')
+
+import navis
+
+
+def with_igraph(func):
+    def wrapper(*args, **kwargs):
+        navis.config.use_igraph = False
+        res1 = func(*args, **kwargs)
+        if igraph:
+            navis.config.use_igraph = True
+            res2 = func(*args, **kwargs)
+            assert res1 == res2
+        return res1
+    return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,19 +11,21 @@ def data_dir():
     return Path(__file__).resolve().parent.parent / "navis" / "data"
 
 
-@pytest.fixture(params=["Path", "pathstr", "swcstr", "textbuffer", "rawbuffer", "DataFrame"])
+@pytest.fixture(
+    params=["Path", "pathstr", "swcstr", "textbuffer", "rawbuffer", "DataFrame"]
+)
 def swc_source(request, data_dir: Path):
     swc_path: Path = data_dir / "swc" / "722817260.swc"
     if request.param == "Path":
         yield swc_path
-    elif request.param == "path-str":
+    elif request.param == "pathstr":
         yield str(swc_path)
-    elif request.param == "swc-str":
+    elif request.param == "swcstr":
         yield swc_path.read_text()
-    elif request.param == "text-buffer":
+    elif request.param == "textbuffer":
         with open(swc_path) as f:
             yield f
-    elif request.param == "bin-buffer":
+    elif request.param == "rawbuffer":
         with open(swc_path, "rb") as f:
             yield f
     elif request.param == "DataFrame":
@@ -32,3 +34,21 @@ def swc_source(request, data_dir: Path):
         yield df
     else:
         raise ValueError("Unknown parameter")
+
+
+@pytest.fixture(
+    params=["dirstr", "dirpath", "list", "listwithdir"],
+)
+def swc_source_multi(request, data_dir: Path):
+    dpath = data_dir / "swc"
+    fpath = dpath / "722817260.swc"
+    if request.param == "dirstr":
+        yield str(dpath)
+    elif request.param == "dirpath":
+        yield dpath
+    elif request.param == "list":
+        yield [fpath, fpath]
+    elif request.param == "listwithdir":
+        yield [dpath, fpath]
+    else:
+        raise ValueError(f"Unknown parameter '{request.param}'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import navis
+
+
+@pytest.fixture
+def data_dir():
+    return Path(__file__).resolve().parent.parent / "navis" / "data"
+
+
+@pytest.fixture(params=["Path", "pathstr", "swcstr", "textbuffer", "rawbuffer", "DataFrame"])
+def swc_source(request, data_dir: Path):
+    swc_path: Path = data_dir / "swc" / "722817260.swc"
+    if request.param == "Path":
+        yield swc_path
+    elif request.param == "path-str":
+        yield str(swc_path)
+    elif request.param == "swc-str":
+        yield swc_path.read_text()
+    elif request.param == "text-buffer":
+        with open(swc_path) as f:
+            yield f
+    elif request.param == "bin-buffer":
+        with open(swc_path, "rb") as f:
+            yield f
+    elif request.param == "DataFrame":
+        df = pd.read_csv(swc_path, " ", header=None, comment="#")
+        df.columns = navis.io.swc_io.NODE_COLUMNS
+        yield df
+    else:
+        raise ValueError("Unknown parameter")

--- a/tests/test_neurons.py
+++ b/tests/test_neurons.py
@@ -1,0 +1,17 @@
+import navis
+
+from .common import with_igraph
+
+
+def test_from_swc(swc_source):
+    n = navis.read_swc(swc_source)
+    assert isinstance(n, navis.TreeNeuron)
+
+
+def test_from_swc_many
+
+
+@with_igraph
+def test_from_gml():
+    n = navis.example_neurons(n=1, source='gml')
+    assert isinstance(n, navis.TreeNeuron)

--- a/tests/test_neurons.py
+++ b/tests/test_neurons.py
@@ -1,5 +1,7 @@
 import navis
 
+import pytest
+
 from .common import with_igraph
 
 
@@ -8,7 +10,10 @@ def test_from_swc(swc_source):
     assert isinstance(n, navis.TreeNeuron)
 
 
-def test_from_swc_many
+@pytest.mark.parametrize("parallel", ["auto", True, 2, False])
+def test_from_swc_multi(swc_source_multi, parallel):
+    n = navis.read_swc(swc_source_multi, parallel=parallel)
+    assert isinstance(n, navis.NeuronList)
 
 
 @with_igraph


### PR DESCRIPTION
This started out as a pretty simple addition to make #10 easier but I rapidly got carried away.

The existing API is unchanged, but would now be a shim over a more rigid `SwcReader` object which has methods for each type of arbitrary object a SWC can be read from. Using these makes it much easier for the caller to reason about and type annotate what they're putting into and getting out of the reader, but maybe this is a personal reference. "Explicit is better than implicit" conflicts with duck typing at times!

Also broadened the SWC reading tests a little, moved them out of the package (I find this makes it easier to detect installation-related issues, and end users don't need the tests anyway), and made them more `pytest`-y. The "old" tests are still in the package, but also don't work by default (because `pymaid` isn't a dependency, which is for the best).

With this implemented, SWCs can be read from zips, tars, and compressed files by opening them with their respective python functions and passing the buffer into the `my_swc_reader.read_buffer()`, which should resolve #10.