### PR TITLE
Allow passing `smat` kwarg through `nblast_allbyall`

### DIFF
--- a/navis/nbl/nblast_funcs.py
+++ b/navis/nbl/nblast_funcs.py
@@ -278,6 +278,7 @@ def nblast_smart(query: Union['core.TreeNeuron', 'core.NeuronList', 'core.Dotpro
                  return_mask: bool = False,
                  normalized: bool = True,
                  use_alpha: bool = False,
+                 smat: Optional[Union[str, pd.DataFrame]] = 'auto',
                  n_cores: int = os.cpu_count() // 2,
                  progress: bool = True,
                  k: int = 20,
@@ -332,6 +333,12 @@ def nblast_smart(query: Union['core.TreeNeuron', 'core.NeuronList', 'core.Dotpro
                     that have lots of branches.
     normalized :    bool, optional
                     Whether to return normalized NBLAST scores.
+    smat :          str | pd.DataFrame
+                    Score matrix. If 'auto' (default), will use scoring matrices
+                    from FCWB. Same behaviour as in R's nat.nblast
+                    implementation. If ``smat=None`` the scores will be
+                    generated as the product of the distances and the dotproduct
+                    of the vectors of nearest-neighbor pairs.
     progress :      bool
                     Whether to show progress bars.
 
@@ -439,6 +446,7 @@ def nblast_smart(query: Union['core.TreeNeuron', 'core.NeuronList', 'core.Dotpro
             # Initialize NBlaster
             this = NBlaster(use_alpha=use_alpha,
                             normalized=normalized,
+                            smat=smat,
                             progress=progress)
             # Add queries and targets
             for n in qq:
@@ -494,6 +502,7 @@ def nblast_smart(query: Union['core.TreeNeuron', 'core.NeuronList', 'core.Dotpro
             # Initialize NBlaster
             this = NBlaster(use_alpha=use_alpha,
                             normalized=normalized,
+                            smat=smat,
                             progress=progress)
             # Add queries and targets
             for n in query_dps[q]:
@@ -548,6 +557,7 @@ def nblast(query: Union['core.TreeNeuron', 'core.NeuronList', 'core.Dotprops'],
                          Literal['max']] = 'forward',
            normalized: bool = True,
            use_alpha: bool = False,
+           smat: Optional[Union[str, pd.DataFrame]] = 'auto',
            n_cores: int = os.cpu_count() // 2,
            progress: bool = True,
            k: int = 20,
@@ -580,9 +590,15 @@ def nblast(query: Union['core.TreeNeuron', 'core.NeuronList', 'core.Dotprops'],
                     individual processes.
     use_alpha :     bool, optional
                     Emphasizes neurons' straight parts (backbone) over parts
-                    that have lots of branches.
+                    that have lots of branches.         
     normalized :    bool, optional
                     Whether to return normalized NBLAST scores.
+    smat :          str | pd.DataFrame
+                    Score matrix. If 'auto' (default), will use scoring matrices
+                    from FCWB. Same behaviour as in R's nat.nblast
+                    implementation. If ``smat=None`` the scores will be
+                    generated as the product of the distances and the dotproduct
+                    of the vectors of nearest-neighbor pairs.
     progress :      bool
                     Whether to show progress bars.
 
@@ -666,6 +682,7 @@ def nblast(query: Union['core.TreeNeuron', 'core.NeuronList', 'core.Dotprops'],
             # Initialize NBlaster
             this = NBlaster(use_alpha=use_alpha,
                             normalized=normalized,
+                            smat=smat,
                             progress=progress)
             # Add queries and targets
             for n in q:
@@ -727,17 +744,17 @@ def nblast_allbyall(x: NeuronList,
                     ``os.cpu_count() - 2``. This should ideally be an even
                     number as that allows optimally splitting queries onto
                     individual processes.
+    use_alpha :     bool, optional
+                    Emphasizes neurons' straight parts (backbone) over parts
+                    that have lots of branches.
+    normalized :    bool, optional
+                    Whether to return normalized NBLAST scores.
     smat :          str | pd.DataFrame, optional
                     Score matrix. If 'auto' (default), will use scoring matrices
                     from FCWB. Same behaviour as in R's nat.nblast
                     implementation. If ``smat=None`` the scores will be
                     generated as the product of the distances and the dotproduct
                     of the vectors of nearest-neighbor pairs.
-    use_alpha :     bool, optional
-                    Emphasizes neurons' straight parts (backbone) over parts
-                    that have lots of branches.
-    normalized :    bool, optional
-                    Whether to return normalized NBLAST scores.
     progress :      bool
                     Whether to show progress bars.
 

--- a/navis/nbl/nblast_funcs.py
+++ b/navis/nbl/nblast_funcs.py
@@ -706,6 +706,7 @@ def nblast(query: Union['core.TreeNeuron', 'core.NeuronList', 'core.Dotprops'],
 def nblast_allbyall(x: NeuronList,
                     normalized: bool = True,
                     use_alpha: bool = False,
+                    smat: Optional[Union[str, pd.DataFrame]] = 'auto',
                     n_cores: int = os.cpu_count() // 2,
                     progress: bool = True,
                     k: int = 20,
@@ -726,6 +727,12 @@ def nblast_allbyall(x: NeuronList,
                     ``os.cpu_count() - 2``. This should ideally be an even
                     number as that allows optimally splitting queries onto
                     individual processes.
+    smat :          str | pd.DataFrame, optional
+                    Score matrix. If 'auto' (default), will use scoring matrices
+                    from FCWB. Same behaviour as in R's nat.nblast
+                    implementation. If ``smat=None`` the scores will be
+                    generated as the product of the distances and the dotproduct
+                    of the vectors of nearest-neighbor pairs.
     use_alpha :     bool, optional
                     Emphasizes neurons' straight parts (backbone) over parts
                     that have lots of branches.
@@ -804,6 +811,7 @@ def nblast_allbyall(x: NeuronList,
             # Initialize NBlaster
             this = NBlaster(use_alpha=use_alpha,
                             normalized=normalized,
+                            smat=smat,
                             progress=progress)
 
             # Make sure we don't add the same neuron twice

--- a/navis/nbl/synblast_funcs.py
+++ b/navis/nbl/synblast_funcs.py
@@ -256,6 +256,7 @@ def synblast(query: Union['core.BaseNeuron', 'core.NeuronList'],
                            Literal['min'],
                            Literal['max']] = 'forward',
              normalized: bool = True,
+             smat: Optional[Union[str, pd.DataFrame]] = 'auto',
              n_cores: int = os.cpu_count() // 2,
              progress: bool = True) -> pd.DataFrame:
     """Synapsed-based variant of NBLAST.
@@ -294,6 +295,12 @@ def synblast(query: Union['core.BaseNeuron', 'core.NeuronList'],
                     individual processes.
     normalized :    bool, optional
                     Whether to return normalized SynBLAST scores.
+    smat :          str | pd.DataFrame, optional
+                    Score matrix. If 'auto' (default), will use scoring matrices
+                    from FCWB. Same behaviour as in R's nat.nblast
+                    implementation. If ``smat=None`` the scores will be
+                    generated as the product of the distances and the dotproduct
+                    of the vectors of nearest-neighbor pairs.
     progress :      bool
                     Whether to show progress bars.
 
@@ -371,6 +378,7 @@ def synblast(query: Union['core.BaseNeuron', 'core.NeuronList'],
             # Initialize SynNBlaster
             this = SynBlaster(normalized=normalized,
                               by_type=by_type,
+                              smat=smat,
                               progress=progress)
             # Add queries and targets
             for nl in [q, t]:


### PR DESCRIPTION
Hi @schlegelp - I was hoping to allow passing the `smat` kwarg to `NBlaster` through the `nblast_allbyall` function.

Note: I saw #28 so let me know if there are any collisions there (possibly just the parameter would need to be copied over description it looked like). 

Let me know if this looks okay or if there's anything you'd want me to revise. 
